### PR TITLE
Use remote placeholders

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'placehold.co',
+        pathname: '/**',
+      },
+    ],
+  },
+};

--- a/src/app/ejemplo-categorias/page.tsx
+++ b/src/app/ejemplo-categorias/page.tsx
@@ -1,0 +1,32 @@
+import CategoryCard from '@/components/CategoryCard';
+
+export default function EjemploCategorias() {
+  return (
+    <div className="p-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <CategoryCard
+        title="Últimos Smartphones"
+        description="Descubre los móviles más recientes y sus características."
+        image="https://placehold.co/400x240?text=Smartphone"
+        category="smartphones"
+      />
+      <CategoryCard
+        title="Nuevos Wearables"
+        description="Relojes inteligentes y accesorios para tu día a día."
+        image="https://placehold.co/400x240?text=Wearable"
+        category="wearables"
+      />
+      <CategoryCard
+        title="Portátiles Recomendados"
+        description="Los mejores laptops para productividad y gaming."
+        image="https://placehold.co/400x240?text=Laptop"
+        category="laptops"
+      />
+      <CategoryCard
+        title="Ecosistema Xiaomi"
+        description="Lo último de la marca en todos sus dispositivos."
+        image="https://placehold.co/400x240?text=Xiaomi"
+        category="xiaomi"
+      />
+    </div>
+  );
+}

--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -1,0 +1,36 @@
+import Image from 'next/image';
+
+export type Category = 'smartphones' | 'wearables' | 'laptops' | 'xiaomi';
+
+export interface CategoryCardProps {
+  title: string;
+  description: string;
+  image: string;
+  category: Category;
+}
+
+const categoryColorMap: Record<Category, string> = {
+  smartphones: 'bg-blue-100 text-blue-800',
+  wearables: 'bg-purple-100 text-purple-800',
+  laptops: 'bg-green-100 text-green-800',
+  xiaomi: 'bg-orange-100 text-orange-800',
+};
+
+export default function CategoryCard({
+  title,
+  description,
+  image,
+  category,
+}: CategoryCardProps) {
+  const colorClasses = categoryColorMap[category];
+
+  return (
+    <div className={`rounded-lg shadow p-4 flex flex-col items-center space-y-2 ${colorClasses}`}>
+      <div className="w-full h-40 relative">
+        <Image src={image} alt={title} fill className="object-cover rounded" />
+      </div>
+      <h3 className="text-lg font-semibold">{title}</h3>
+      <p className="text-sm text-center">{description}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- remove local images and use remote placeholders
- add `next.config.js` with remotePatterns
- replace category images with placeholder URLs

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ef888cf7c8326a21a40bd74808aa5